### PR TITLE
Update footer

### DIFF
--- a/apps/challenge-registry/src/_app-theme.scss
+++ b/apps/challenge-registry/src/_app-theme.scss
@@ -1,20 +1,26 @@
 @use '@angular/material' as mat;
+@use 'palette' as pal;
 @use 'libs/challenge-registry/themes/src/index' as challenge-registry;
 
 @include mat.core();
 
-$primary: mat.define-palette(mat.$indigo-palette, 500);
-$accent: mat.define-palette(mat.$pink-palette, A200, A100, A400);
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500&display=swap');
 
-$theme: mat.define-light-theme((
- color: (
-   primary: $primary,
-   accent: $accent,
- ),
- typography: mat.define-typography-config(
-    $font-family: 'Roboto',
+$primary: mat.define-palette(pal.$dark-blue-palette, 600);
+$accent: mat.define-palette(pal.$accent-pink-palette, 400);
+
+$theme: mat.define-light-theme(
+  (
+    color: (
+      primary: $primary,
+      accent: $accent,
+    ),
+    typography:
+      mat.define-typography-config(
+        $font-family: "'Poppins', sans-serif",
+      ),
   )
-));
+);
 
 // Emit theme-dependent styles for common features used across multiple
 // components.

--- a/apps/challenge-registry/src/_palette.scss
+++ b/apps/challenge-registry/src/_palette.scss
@@ -32,15 +32,15 @@ $dark-blue-palette: (
     600: $light-primary-text,
     700: $light-primary-text,
     800: $light-primary-text,
-    900: $light-primary-text
-  )
+    900: $light-primary-text,
+  ),
 );
 
 $light-blue-palette: (
   50: #dff4fb,
   100: #ade3f4,
   200: #76d1ed,
-  300: #39BDE7,
+  300: #39bde7,
   400: #00b1e5,
   500: #00a4e3,
   600: #0096d5,
@@ -57,8 +57,8 @@ $light-blue-palette: (
     600: $dark-primary-text,
     700: $dark-primary-text,
     800: $light-primary-text,
-    900: $light-primary-text
-  )
+    900: $light-primary-text,
+  ),
 );
 
 $light-pink-palette: (
@@ -82,8 +82,8 @@ $light-pink-palette: (
     600: $dark-primary-text,
     700: $light-primary-text,
     800: $light-primary-text,
-    900: $light-primary-text
-  )
+    900: $light-primary-text,
+  ),
 );
 
 $light-orange-palette: (
@@ -107,8 +107,8 @@ $light-orange-palette: (
     600: $dark-primary-text,
     700: $dark-primary-text,
     800: $dark-primary-text,
-    900: $light-primary-text
-  )
+    900: $light-primary-text,
+  ),
 );
 
 $light-green-palette: (
@@ -132,8 +132,8 @@ $light-green-palette: (
     600: $dark-primary-text,
     700: $dark-primary-text,
     800: $dark-primary-text,
-    900: $dark-primary-text
-  )
+    900: $dark-primary-text,
+  ),
 );
 
 $light-purple-palette: (
@@ -157,8 +157,8 @@ $light-purple-palette: (
     600: $light-primary-text,
     700: $light-primary-text,
     800: $light-primary-text,
-    900: $light-primary-text
-  )
+    900: $light-primary-text,
+  ),
 );
 
 // Alias for "accent" usage

--- a/libs/challenge-registry/ui/src/_lib-theme.scss
+++ b/libs/challenge-registry/ui/src/_lib-theme.scss
@@ -1,26 +1,6 @@
-@use '@angular/material' as mat;
-
-@use './lib/palette' as pal;
 @use './lib/button-github/button-github-theme' as button-github;
 @use './lib/footer/footer-theme' as footer;
 @use './lib/navbar/navbar-theme' as navbar;
-
-@include mat.core();
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500&display=swap');
-
-$primary: mat.define-palette(pal.$dark-blue-palette, 600);
-$accent: mat.define-palette(pal.$accent-pink-palette, 400);
-
-$theme: mat.define-light-theme((
-  color: (
-    primary: $primary,
-    accent: $accent,
-  ),
-  typography:
-    mat.define-typography-config(
-      $font-family: "'Poppins', sans-serif",
-    ),
-));
 
 @mixin theme($theme) {
   @include button-github.theme($theme);

--- a/libs/challenge-registry/ui/src/lib/footer/_footer-theme.scss
+++ b/libs/challenge-registry/ui/src/lib/footer/_footer-theme.scss
@@ -1,8 +1,6 @@
 @use 'sass:map';
 @use '@angular/material' as mat;
 
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500&display=swap');
-
 @mixin color($theme) {
   $config: mat.get-color-config($theme);
   $primary: map.get($config, 'primary');
@@ -13,7 +11,8 @@
     background-color: mat.get-color-from-palette($primary, 600);
     color: #fff;
   }
-  .footer-link-group a, .footer-links a {
+  .footer-link-group a,
+  .footer-links a {
     color: #fff;
   }
   .footer-bottom {
@@ -23,12 +22,29 @@
 
 @mixin typography($theme) {
   $typography-config: mat.get-typography-config($theme);
+  $font-family: map.get($typography-config, 'font-family');
 
   footer {
-    // FIXME: Angular theming not applying typography from theme mixin for some reason?
-    font-family: 'Poppins', sans-serif;
-    font-weight: 500px;
+    font-family: $font-family;
+    font-weight: 500;
     line-height: normal;
+  }
+  .right-section {
+    font-size: 12px;
+  }
+  .footer-main {
+    font-size: 36px;
+  }
+  .footer-subtext {
+    font-size: 15px;
+    font-weight: 500px;
+  }
+  .footer-link-group {
+    font-size: 18px;
+  }
+  .footer-links,
+  .footer-links a {
+    font-size: 16px;
   }
 }
 

--- a/libs/challenge-registry/ui/src/lib/footer/footer.component.scss
+++ b/libs/challenge-registry/ui/src/lib/footer/footer.component.scss
@@ -19,7 +19,6 @@ footer {
 }
 .right-section {
   flex: 1 1 auto;
-  font-size: 12px;
   text-align: right;
   line-height: 15px;
   display: flex;
@@ -28,19 +27,15 @@ footer {
 }
 .footer-main {
   margin: 0;
-  font-size: 36px;
   line-height: 32px;
 }
 .footer-subtext {
-  font-size: 15px;
   align-self: auto;
-  font-weight: 500px;
 }
 .footer-link-group {
   width: 250px;
   height: 30px;
   padding: 0;
-  font-size: 18px;
   display: flex;
   justify-content: space-between;
   list-style: none;
@@ -63,8 +58,8 @@ footer {
   align-items: center;
   justify-content: center;
 }
-.footer-links, .footer-links a {
-  font-size: 16px;
+.footer-links,
+.footer-links a {
   text-decoration: none;
 }
 .footer-links a:hover {


### PR DESCRIPTION
@vpchung Here are the changes I made:

1. I assume the palettes and fonts are used globally for `challenge-registry` project, so I move the themes from `libs/challenge-registry/ui/src/_lib-theme.scss` to `apps/challenge-registry/src/_app-theme.scss`. In this way, other libs outside of `ui` library, like homepage, can also use this theme. 
2. I update the code to extract the fonts from the config in `_footer-theme.scss`, so we don't need to import fonts each component.
3. I move all "fonts-*" styles into typography.